### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Run on Repl.it](https://repl.it/badge/github/muniz95/nokia3310)](https://repl.it/github/muniz95/nokia3310)
+
 This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).
 
 Below you will find some information on how to perform common tasks.<br>


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@muniz95/nokia3310).